### PR TITLE
Fixed google fonts to use http or https

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link href="assets/css/main.css" rel="stylesheet">
 
     <!-- Fonts from Google Fonts -->
-	<link href='http://fonts.googleapis.com/css?family=Lato:300,400,900' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Lato:300,400,900' rel='stylesheet' type='text/css'>
     
   
   </head>


### PR DESCRIPTION
Removing the http: and leaving the // will allow the browser to pick which to use http or https.
